### PR TITLE
Fixes for hotkeys

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,5 +42,19 @@ app.on('ready', function () {
     shell.openExternal(url)
   })
 
+  // Prevent copy and cut from being stolen by other hotkeys
+  win.webContents.on('before-input-event', (e, input) => {
+    if (input.key === 'c' && input.control) {
+      win.webContents.copy();
+      e.preventDefault();
+      return false;
+    }
+    if (input.key === 'x' && input.control) {
+      win.webContents.cut();
+      e.preventDefault();
+      return false;
+    }
+  })
+
   win.show()
 })

--- a/src/menu.js
+++ b/src/menu.js
@@ -4,13 +4,11 @@ module.exports = [
     submenu: [
       {
         label: 'Undo',
-        accelerator: 'CmdOrCtrl+Z',
         selector: 'undo:',
         role: 'undo',
       },
       {
         label: 'Redo',
-        accelerator: 'Shift+CmdOrCtrl+Z',
         selector: 'redo:',
         role: 'redo',
       },
@@ -19,25 +17,21 @@ module.exports = [
       },
       {
         label: 'Cut',
-        accelerator: 'CmdOrCtrl+X',
         selector: 'cut:',
         role: 'cut',
       },
       {
         label: 'Copy',
-        accelerator: 'CmdOrCtrl+C',
         selector: 'copy:',
         role: 'copy',
       },
       {
         label: 'Paste',
-        accelerator: 'CmdOrCtrl+V',
         selector: 'paste:',
         role: 'paste',
       },
       {
         label: 'Select All',
-        accelerator: 'CmdOrCtrl+A',
         selector: 'selectAll:',
         role: 'selectall',
       },


### PR DESCRIPTION
Issue: Hotkeys for Cut/Copy/Paste/Undo/Redo/SelectAll. were not working on Ubuntu 17.10
Fix: Remove the "accelerator" attribute so that the defaults are used by electron based on the "role" attribute for Cut, etc.

Issue: OWA uses the "c" hotkey to open the categories menu and the "x" hotkey for expand message. These hotkeys don't check the control modifier, and when used in electron override the copy and cut shortcuts. 
Fix: Call e.preventDefault when Ctrl+C and Ctrl+X are pressed.