### PR TITLE
Fixes for reload and file download

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,8 +38,11 @@ app.on('ready', function () {
   })
 
   win.webContents.on('new-window', function (event, url) {
-    event.preventDefault()
-    shell.openExternal(url)
+    // outlook.office.com links should open in the electron container.
+    if (url && !url.includes('outlook.office.com')) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
   })
 
   // Prevent copy and cut from being stolen by other hotkeys

--- a/src/menu.js
+++ b/src/menu.js
@@ -45,7 +45,7 @@ module.exports = [
         accelerator: 'CmdOrCtrl+R',
         click: function (item, focusedWindow) {
           if (focusedWindow) {
-            focusedWindow.reload()
+            focusedWindow.loadURL('https://portal.microsoftonline.com');
           }
         },
       },


### PR DESCRIPTION
- File download links would open in the external browser, but would fail to download the file. This change opens internal links such as file download links in the electron container.
- If your session expires, the electron app gets stuck on the logged out "Please close your browser" screen. This change allows the user to choose "Reload" to get back to the login screen.